### PR TITLE
Combine modem and L2 into a single process

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -7,6 +7,7 @@ tetra-rx
 tetra-rx-dmo
 tetra-dmo-rep
 hamtetra_main
+hamtetra_main2
 float_to_bits
 crc_test
 tunctl

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,9 +1,11 @@
 CFLAGS=-g -Wall `pkg-config --cflags libosmocore 2> /dev/null` -I. -I../../suo/libsuo
 LDLIBS=`pkg-config --libs libosmocore 2> /dev/null` -losmocore -lzmq -lm -lpthread
+# These are only needed for hamtetra_main2:
+LDLIBS += -lSoapySDR -lliquid
 
 # all: conv_enc_test crc_test tetra-rx tetra-rx-dmo float_to_bits tunctl tetra-dmo-rep
 #all: conv_enc_test crc_test float_to_bits tunctl tetra-dmo-rep hamtetra_main
-all: conv_enc_test crc_test float_to_bits tunctl hamtetra_main
+all: conv_enc_test crc_test float_to_bits tunctl hamtetra_main hamtetra_main2
 
 debug: CFLAGS := -lasan $(CFLAGS) -fsanitize=address -fno-omit-frame-pointer -g -O0
 debug: LDLIBS := -lasan $(LDLIBS)
@@ -27,6 +29,8 @@ crc_test: crc_test.o tetra_common.o libosmo-tetra-mac.a
 tetra-dmo-rep: tetra-dmo-rep.o libosmo-tetra-phy.a libosmo-tetra-mac.a
 
 hamtetra_main: hamtetra_main.o hamtetra_timing.o hamtetra_slotter.o tetra-dmo-rep.o libosmo-tetra-phy.a libosmo-tetra-mac.a
+
+hamtetra_main2: hamtetra_main2.o hamtetra_timing.o hamtetra_slotter.o tetra-dmo-rep.o libosmo-tetra-phy.a libosmo-tetra-mac.a ../../suo/libsuo/build/libsuo-dsp.a ../../suo/libsuo/build/libsuo-io.a
 
 conv_enc_test: conv_enc_test.o testpdu.o libosmo-tetra-phy.a libosmo-tetra-mac.a
 

--- a/src/hamtetra_main.c
+++ b/src/hamtetra_main.c
@@ -20,6 +20,9 @@ struct burst_bits {
 
 int main(void)
 {
+	// Parameter: how long beforehand a burst is produced
+	uint64_t tx_ahead_time = 12.5e6;
+
 	void *zmq_rx_socket, *zmq_tx_socket;
 	zmq_context = zmq_ctx_new();
 
@@ -65,7 +68,7 @@ int main(void)
 			/* It's a transmitter tick */
 
 			int len;
-			uint64_t ts = rx_msg.m.time;
+			uint64_t ts = rx_msg.m.time + tx_ahead_time;
 			len = timing_tx_burst(timing1, tx_msg.data, BURST_MAXBITS, &ts);
 
 			if (len >= 0) {

--- a/src/hamtetra_main2.c
+++ b/src/hamtetra_main2.c
@@ -1,0 +1,118 @@
+/* Alternative main program that directly plugs the L1/L2 protocol stack
+ * into libsuo. This way, it runs in the same thread with signal processing
+ * in the modem. */
+
+#include <assert.h>
+#include "suo.h"
+#include "hamtetra_timing.h"
+#include "hamtetra_slotter.h"
+#include "signal-io/soapysdr_io.h"
+#include "modem/burst_dpsk_receiver.h"
+#include "modem/psk_transmitter.h"
+
+struct timing_state *timing1;
+struct slotter_state *slotter1;
+
+#define BURST_MAXBITS 600
+struct burst_bits {
+	struct metadata m;
+	uint8_t data[BURST_MAXBITS];
+};
+
+
+static int hamtetra_rx_output_frame(void *arg, const struct frame *in)
+{
+	int len = in->m.len;
+	if (len < 0 || len > BURST_MAXBITS)
+		return -1;
+
+	struct burst_bits b;
+	b.m = in->m;
+
+	/* Convert to bits by hard decision */
+	int i;
+	for (i = 0; i < len; i++)
+		b.data[i] = in->data[i] >= 0x80 ? 1 : 0;
+
+	return timing_rx_burst(timing1, b.data, len, b.m.time);
+}
+
+
+static int hamtetra_tx_input_frame(void *arg, struct frame *out, size_t maxlen, timestamp_t timenow)
+{
+	int len;
+	uint64_t ts = timenow;
+	len = timing_tx_burst(timing1, out->data, BURST_MAXBITS, &ts);
+	if (len >= 0) {
+		assert(len <= BURST_MAXBITS);
+		out->m.len = len;
+		out->m.time = ts;
+		out->m.flags = METADATA_TIME | METADATA_NO_LATE;
+	}
+	return len;
+}
+
+
+static int dummy_tick(void *arg, timestamp_t timenow)
+{
+	(void)arg; (void)timenow;
+	return 0;
+}
+
+
+const struct rx_output_code hamtetra_rx_output_code = { "HamTetra", NULL, NULL, NULL, NULL, NULL, hamtetra_rx_output_frame, dummy_tick };
+
+const struct tx_input_code hamtetra_tx_input_code = { "HamTetra", NULL, NULL, NULL, NULL, NULL, hamtetra_tx_input_frame, dummy_tick };
+
+
+int main(void)
+{
+	const double samplerate = 0.5e6;
+
+	// Operating frequency
+	const double tetra_freq = 416.2375e6;
+
+	// Offset from SDR center frequency to avoid 1/f noise and DC
+	const double offset_freq = 37500;
+
+	slotter1 = slotter_init();
+	timing1 = timing_init();
+
+	// Less timing margin is enough here
+	timing1->ahead_time = 3e6;
+
+	timing1->slotter = slotter1;
+	slotter1->timing = timing1;
+
+	struct burst_dpsk_receiver_conf *rx_conf = burst_dpsk_receiver_code.init_conf();
+	rx_conf->samplerate = samplerate;
+	rx_conf->centerfreq = offset_freq;
+	void *rx_arg = burst_dpsk_receiver_code.init(rx_conf);
+
+	burst_dpsk_receiver_code.set_callbacks(rx_arg, &hamtetra_rx_output_code, NULL);
+
+	struct psk_transmitter_conf *tx_conf = psk_transmitter_code.init_conf();
+	tx_conf->samplerate = samplerate;
+	tx_conf->centerfreq = offset_freq;
+	void *tx_arg = psk_transmitter_code.init(tx_conf);
+
+	psk_transmitter_code.set_callbacks(tx_arg, &hamtetra_tx_input_code, NULL);
+
+	struct soapysdr_io_conf *io_conf = soapysdr_io_code.init_conf();
+	io_conf->samplerate = samplerate;
+	io_conf->rx_centerfreq =
+	io_conf->tx_centerfreq = tetra_freq - offset_freq;
+	io_conf->rx_antenna = "LNAL";
+	io_conf->tx_antenna = "BAND1";
+	io_conf->rx_gain = 50;
+	io_conf->tx_gain = 50;
+	io_conf->buffer = 1024;
+	io_conf->tx_latency = 6144;
+	soapysdr_io_code.set_conf(io_conf, "soapy-driver", "lime");
+	void *io_arg = soapysdr_io_code.init(io_conf);
+
+	soapysdr_io_code.set_callbacks(io_arg, &burst_dpsk_receiver_code, rx_arg, &psk_transmitter_code, tx_arg);
+	soapysdr_io_code.execute(io_arg);
+
+	return 0;
+}

--- a/src/hamtetra_main2.c
+++ b/src/hamtetra_main2.c
@@ -45,12 +45,12 @@ static int hamtetra_rx_output_frame(void *arg, const struct frame *in)
 static int hamtetra_tx_input_frame(void *arg, struct frame *out, size_t maxlen, timestamp_t timenow)
 {
 	int len;
-	uint64_t ts = timenow;
+	uint64_t ts = timenow + 3000000; // TODO: make suo give the correct deadline;
 	len = timing_tx_burst(timing1, out->data, BURST_MAXBITS, &ts);
 	if (len >= 0) {
 		assert(len <= BURST_MAXBITS);
 		out->m.len = len;
-		out->m.time = ts + 3000000; // TODO: make suo give the correct deadline
+		out->m.time = ts;
 		out->m.flags = METADATA_TIME | METADATA_NO_LATE;
 	}
 	return len;
@@ -126,6 +126,7 @@ static int hamtetra_init(const char *hw, double tetra_freq)
 	struct burst_dpsk_receiver_conf *rx_conf = burst_dpsk_receiver_code.init_conf();
 	rx_conf->samplerate = samplerate;
 	rx_conf->centerfreq = offset_freq;
+	rx_conf->syncpos = 143; // To get complete slots for DMO
 	void *rx_arg = burst_dpsk_receiver_code.init(rx_conf);
 
 	if (rx_arg == NULL)

--- a/src/hamtetra_main2.c
+++ b/src/hamtetra_main2.c
@@ -2,19 +2,23 @@
  * into libsuo. This way, it runs in the same thread with signal processing
  * in the modem. */
 
-#include <assert.h>
 #include "suo.h"
 #include "hamtetra_timing.h"
 #include "hamtetra_slotter.h"
 #include "signal-io/soapysdr_io.h"
 #include "modem/burst_dpsk_receiver.h"
 #include "modem/psk_transmitter.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
 
 struct timing_state *timing1;
 struct slotter_state *slotter1;
+static const struct signal_io_code *io_code;
+static void *io_arg;
 
 #define BURST_MAXBITS 600
-struct burst_bits {
+struct burst_msg {
 	struct metadata m;
 	uint8_t data[BURST_MAXBITS];
 };
@@ -26,7 +30,7 @@ static int hamtetra_rx_output_frame(void *arg, const struct frame *in)
 	if (len < 0 || len > BURST_MAXBITS)
 		return -1;
 
-	struct burst_bits b;
+	struct burst_msg b;
 	b.m = in->m;
 
 	/* Convert to bits by hard decision */
@@ -46,7 +50,7 @@ static int hamtetra_tx_input_frame(void *arg, struct frame *out, size_t maxlen, 
 	if (len >= 0) {
 		assert(len <= BURST_MAXBITS);
 		out->m.len = len;
-		out->m.time = ts;
+		out->m.time = ts + 3000000; // TODO: make suo give the correct deadline
 		out->m.flags = METADATA_TIME | METADATA_NO_LATE;
 	}
 	return len;
@@ -65,29 +69,67 @@ const struct rx_output_code hamtetra_rx_output_code = { "HamTetra", NULL, NULL, 
 const struct tx_input_code hamtetra_tx_input_code = { "HamTetra", NULL, NULL, NULL, NULL, NULL, hamtetra_tx_input_frame, dummy_tick };
 
 
-int main(void)
+static int hamtetra_init(const char *hw, double tetra_freq)
 {
-	const double samplerate = 0.5e6;
-
-	// Operating frequency
-	const double tetra_freq = 416.2375e6;
+	// Sample rate for SDR
+	double samplerate = 0.5e6;
 
 	// Offset from SDR center frequency to avoid 1/f noise and DC
-	const double offset_freq = 37500;
+	double offset_freq = 37500;
 
 	slotter1 = slotter_init();
 	timing1 = timing_init();
 
-	// Less timing margin is enough here
-	timing1->ahead_time = 3e6;
-
 	timing1->slotter = slotter1;
 	slotter1->timing = timing1;
+
+	if (strcmp(hw, "file") == 0) {
+		return -1; // not implemented
+		//io_code = &file_io_code;
+		// TODO: file I/O
+	} else {
+		io_code = &soapysdr_io_code;
+		struct soapysdr_io_conf *io_conf = soapysdr_io_code.init_conf();
+		io_conf->samplerate = samplerate;
+		io_conf->rx_centerfreq =
+		io_conf->tx_centerfreq = tetra_freq - offset_freq;
+		io_conf->buffer = 1024;
+		io_conf->tx_latency = 6144;
+
+		// SDR specific configuration
+		if (strcmp(hw, "limesdr") == 0) {
+			soapysdr_io_code.set_conf(io_conf, "soapy-driver", "lime");
+			io_conf->rx_antenna = "LNAL";
+			io_conf->tx_antenna = "BAND1";
+		} else if (strcmp(hw, "limemini") == 0) {
+			soapysdr_io_code.set_conf(io_conf, "soapy-driver", "lime");
+			io_conf->rx_antenna = "LNAW";
+			io_conf->tx_antenna = "BAND2";
+		} else if (strcmp(hw, "limenet") == 0) {
+			soapysdr_io_code.set_conf(io_conf, "soapy-driver", "lime");
+			io_conf->rx_antenna = "LNAL";
+			io_conf->tx_antenna = "BAND2";
+		} else if (strcmp(hw, "usrp") == 0) {
+			soapysdr_io_code.set_conf(io_conf, "soapy-driver", "uhd");
+			io_conf->rx_antenna = "TX/RX";
+			io_conf->tx_antenna = "TX/RX";
+		} else {
+			return -1;
+		}
+		io_conf->rx_gain = 50;
+		io_conf->tx_gain = 50;
+		io_arg = soapysdr_io_code.init(io_conf);
+	}
+	if (io_arg == NULL)
+		return -1;
 
 	struct burst_dpsk_receiver_conf *rx_conf = burst_dpsk_receiver_code.init_conf();
 	rx_conf->samplerate = samplerate;
 	rx_conf->centerfreq = offset_freq;
 	void *rx_arg = burst_dpsk_receiver_code.init(rx_conf);
+
+	if (rx_arg == NULL)
+		return -1;
 
 	burst_dpsk_receiver_code.set_callbacks(rx_arg, &hamtetra_rx_output_code, NULL);
 
@@ -96,23 +138,38 @@ int main(void)
 	tx_conf->centerfreq = offset_freq;
 	void *tx_arg = psk_transmitter_code.init(tx_conf);
 
+	if (tx_arg == NULL)
+		return -1;
+
 	psk_transmitter_code.set_callbacks(tx_arg, &hamtetra_tx_input_code, NULL);
 
-	struct soapysdr_io_conf *io_conf = soapysdr_io_code.init_conf();
-	io_conf->samplerate = samplerate;
-	io_conf->rx_centerfreq =
-	io_conf->tx_centerfreq = tetra_freq - offset_freq;
-	io_conf->rx_antenna = "LNAL";
-	io_conf->tx_antenna = "BAND1";
-	io_conf->rx_gain = 50;
-	io_conf->tx_gain = 50;
-	io_conf->buffer = 1024;
-	io_conf->tx_latency = 6144;
-	soapysdr_io_code.set_conf(io_conf, "soapy-driver", "lime");
-	void *io_arg = soapysdr_io_code.init(io_conf);
+	io_code->set_callbacks(io_arg, &burst_dpsk_receiver_code, rx_arg, &psk_transmitter_code, tx_arg);
+	return 0;
+}
 
-	soapysdr_io_code.set_callbacks(io_arg, &burst_dpsk_receiver_code, rx_arg, &psk_transmitter_code, tx_arg);
-	soapysdr_io_code.execute(io_arg);
+
+int main(int argc, char *argv[])
+{
+	if (argc != 3) {
+		fprintf(stderr,
+			"Use: %s HARDWARE FREQUENCY\n"
+			"HARDWARE options are:\n"
+			"   limesdr   LimeSDR USB, antennas on RX1_L and TX1_1 ports\n"
+			"   limemini  LimeSDR Mini\n"
+			"   limenet   LimeNET Micro\n"
+			"   usrp      USRP B200\n"
+			"FREQUENCY is TETRA signal center frequency in MHz.\n"
+			"For example: %s limemini 416.2375\n",
+			argv[0], argv[0]);
+		return 1;
+	}
+
+	if (hamtetra_init(argv[1], 1e6 * atof(argv[2])) < 0) {
+		fprintf(stderr, "Initialization failed\n");
+		return 2;
+	}
+
+	io_code->execute(io_arg);
 
 	return 0;
 }

--- a/src/hamtetra_slotter.c
+++ b/src/hamtetra_slotter.c
@@ -1,4 +1,9 @@
-/* Process and produce bursts based on their timeslot number */
+/* Process and produce bursts based on their timeslot number.
+ *
+ * This is where the L2 protocols, i.e. lower-MAC and upper-MAC run.
+ * The calls from hamtetra_timing.c to here roughly correspond
+ * to the DP-SAP interface in TETRA specifications.
+ */
 
 #include "hamtetra_slotter.h"
 #include "phy/tetra_burst.h"

--- a/src/hamtetra_timing.c
+++ b/src/hamtetra_timing.c
@@ -19,7 +19,6 @@ struct timing_state *timing_init()
 	s = calloc(1, sizeof(*s));
 
 	s->slot_time = 1e9 * 255.0 / 18000.0 + 0.5;
-	s->ahead_time = 12.5e6;
 
 	return s;
 }
@@ -54,16 +53,17 @@ int timing_rx_burst(struct timing_state *s, const uint8_t *bits, int len, uint64
 
 int timing_tx_burst(struct timing_state *s, uint8_t *bits, int maxlen, uint64_t *ts)
 {
+	const int64_t time_margin = 0;
 	int retlen = -1;
 	uint64_t tnow = *ts;
 	if (s->tx_time == 0) {
 		// Initialize timing on first tick
-		s->tx_time = tnow + s->ahead_time + s->slot_time;
+		s->tx_time = tnow + s->slot_time*2;
 	}
 
 	const uint64_t tx_time = s->tx_time;
 	int64_t tdiff = tnow - tx_time;
-	if (tdiff >= -s->ahead_time) {
+	if (tdiff >= -time_margin) {
 		const unsigned slot = s->tx_slot;
 
 		struct timing_slot tslot = {

--- a/src/hamtetra_timing.c
+++ b/src/hamtetra_timing.c
@@ -1,5 +1,11 @@
 /* Convert between burst timestamps and timeslot numbers.
- * Handle timing of producing transmit bursts. */
+ * Handle timing of producing transmit bursts.
+ *
+ * In terms of TETRA specification, a part of the L1 (physical layer)
+ * happens here. Rest of L1 happens in the modem, which synchronizes
+ * to individual received bursts based on their training sequences
+ * and then delivers them here.
+ */
 
 #include "hamtetra_timing.h"
 #include "hamtetra_slotter.h"

--- a/src/hamtetra_timing.h
+++ b/src/hamtetra_timing.h
@@ -12,10 +12,16 @@ struct timing_state {
 
 	// Parameter: length of a slot
 	uint64_t slot_time;
+	// Length of a symbol
+	int64_t sym_time;
 
 	// Next transmission slot
 	uint64_t tx_time;
 	unsigned tx_slot; // Combined slot number, counting from 0 to 4319
+
+	unsigned char prev_dmo; // Flag: a DMO burst was transmitted in the previous slot
+
+	unsigned char use_interslot_bits; // Configuration flag
 };
 
 struct timing_slot {
@@ -51,7 +57,10 @@ int timing_rx_burst(struct timing_state *s, const uint8_t *bits, int len, uint64
  * -1 if there is no burst to transmit at the moment.
  *
  * Timestamp of the burst is returned in *ts.
- * The current time of the modulator is given in *ts. */
+ * A "deadline" is given in *ts:
+ * if a burst should be transmitted before the time given in *ts,
+ * it should be returned in this call.
+ */
 int timing_tx_burst(struct timing_state *s, uint8_t *bits, int maxlen, uint64_t *ts);
 
 /* Resynchronize time counters. */

--- a/src/hamtetra_timing.h
+++ b/src/hamtetra_timing.h
@@ -12,8 +12,6 @@ struct timing_state {
 
 	// Parameter: length of a slot
 	uint64_t slot_time;
-	// Parameter: how long beforehand a burst is produced
-	int64_t ahead_time;
 
 	// Next transmission slot
 	uint64_t tx_time;

--- a/src/phy/tetra_burst.c
+++ b/src/phy/tetra_burst.c
@@ -294,10 +294,6 @@ int build_dm_sync_burst(uint8_t *buf, const uint8_t *bkn1, const uint8_t *bkn2)
 	uint8_t *cur = buf;
 	uint8_t *hl;
 
-	/* preceding interslot guard bits */
-	memcpy(cur, g_bits+6, 34);
-	cur += 34;
-
 	/* Preamble bits: l1 to l12 */
 	memcpy(cur, l_bits, 12);
 	cur += 12;
@@ -325,10 +321,6 @@ int build_dm_sync_burst(uint8_t *buf, const uint8_t *bkn1, const uint8_t *bkn2)
 	/* Tail bits: t1 to t2 */
 	memcpy(cur, t_bits+2, 2);
 	cur += 2;
-
-	/* following interslot guard bits */
-	memcpy(cur, g_bits, 6);
-	cur += 6;
 
 	/* put in the phase adjustment bits */
 	put_phase_adj_bits(buf, HL, hl);

--- a/src/phy/tetra_burst_bits.h
+++ b/src/phy/tetra_burst_bits.h
@@ -6,18 +6,18 @@
  * synchronizer in the modem. */
 
 struct dmo_normal_bits {
-	uint8_t begin[14]; // Unused bits at beginning
+	uint8_t guard1[34]; // Unused bits at beginning
 	uint8_t preamble[12];
 	uint8_t phase_adj[2];
 	uint8_t block1[216];
 	uint8_t train[22];
 	uint8_t block2[216];
 	uint8_t tail[2];
-	uint8_t end[26]; // Unused bits at end
+	uint8_t guard2[6]; // Unused bits at end
 };
 
 struct dmo_sync_bits {
-	uint8_t begin[14]; // Unused bits at beginning
+	uint8_t guard1[34]; // Unused bits at beginning
 	uint8_t preamble[12];
 	uint8_t phase_adj[2];
 	uint8_t freq_corr[80];
@@ -25,7 +25,7 @@ struct dmo_sync_bits {
 	uint8_t train[38];
 	uint8_t block2[216];
 	uint8_t tail[2];
-	uint8_t end[26]; // Unused bits at end
+	uint8_t guard2[6]; // Unused bits at end
 };
 
 #endif


### PR DESCRIPTION
Add hamtetra_main2.c which puts the L2 protocol stack directly into libsuo callbacks. Running the protocol and signal processing in one thread makes it easier to control latencies.